### PR TITLE
Update link to description of Stats19 database

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,7 +296,7 @@
 					
 					<div id="collisions">
 						<h2>Collisions</h2>
-						<p>Although cycling is not an inherently unsafe activity, collisions are more frequent than they should be due to lack of cycle infrastructure. Data is from DfT/police STATS19, from 1999-2020. See <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/230596/stats20-2011.pdf" target="_blank">definitions</a>.</p>
+						<p>Although cycling is not an inherently unsafe activity, collisions are more frequent than they should be due to lack of cycle infrastructure. Data is from DfT/police STATS19, from 1999-2020. See <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/995423/stats20-2011.pdf" target="_blank">definitions</a>.</p>
 						<p>Zoom in to see all - while zoomed out only a selection is shown due to the volume.</p>
 						
 						<div class="filters">


### PR DESCRIPTION
Replacing dead link with live one [here](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/995423/stats20-2011.pdf)